### PR TITLE
Kc email invite

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,11 @@
+class InvitesController < ApplicationController
+  def new
+  end
+
+  def create
+    # require "pry"; binding.pry
+    # current_user
+
+    redirect_to '/dashboard'
+  end
+end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -8,7 +8,7 @@ class InvitesController < ApplicationController
     if invited.values.include?("Bad credentials")
       flash[:failure] = "Please connect to github before sending invites"
     elsif !invited[:email].nil?
-      send_invite(invited[:email])
+      send_invite(invited, current_user)
       flash[:success] = "Successfully sent invite!"
     elsif invited[:email].nil?
       flash[:failure] = "The Github user you selected doesn't have an email address associated with their account."
@@ -19,8 +19,8 @@ class InvitesController < ApplicationController
 
   private
 
-  def send_invite(email)
-    InvitationMailer.invite(email).deliver_now
+  def send_invite(github_user, inviter)
+    InvitationMailer.invite(github_user).deliver_now
   end
 
   def api_conn

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -20,7 +20,7 @@ class InvitesController < ApplicationController
   private
 
   def send_invite(github_user, inviter)
-    InvitationMailer.invite(github_user).deliver_now
+    InvitationMailer.invite(github_user, inviter).deliver_now
   end
 
   def api_conn

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -3,9 +3,27 @@ class InvitesController < ApplicationController
   end
 
   def create
-    # require "pry"; binding.pry
-    # current_user
+    invited = api_conn.get_user(params[:handle])
+
+    if invited.values.include?("Bad credentials")
+      flash[:failure] = "Please connect to github before sending invites"
+    elsif !invited[:email].nil?
+      send_invite(invited[:email])
+      flash[:success] = "Successfully sent invite!"
+    elsif invited[:email].nil?
+      flash[:failure] = "The Github user you selected doesn't have an email address associated with their account."
+    end
 
     redirect_to '/dashboard'
+  end
+
+  private
+
+  def send_invite(email)
+    InvitationMailer.invite(email).deliver_now
+  end
+
+  def api_conn
+    GithubService.new(current_user.token)
   end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,7 @@
+class InvitationMailer < ApplicationMailer
+  def invite(github_user, inviter)
+    @name = github_user[:name]
+    @inviter = inviter[:first_name] + " " + inviter[:last_name]
+    mail(to: github_user[:email], subject: "You've been invited to join Turing Video Tutorials!")
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -15,6 +15,10 @@ class GithubService
     get_json('/user/following')
   end
 
+  def get_user(handle)
+    get_json("/users/#{handle}")
+  end
+
   private
 
     def conn

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,3 @@
+Hello <%= @name %>,
+
+<%= @inviter %> has invited you to join Turing Video Tutorials. You can create an account <%= link_to "here", "https://warm-reaches-79802.herokuapp.com/signup"%>.

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @name %>,
+
+<%= @inviter %> has invited you to join Turing Video Tutorials. You can create an account <%= link_to "here", "https://warm-reaches-79802.herokuapp.com/signup"%>.

--- a/app/views/invites/new.html.erb
+++ b/app/views/invites/new.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag new_invite_path, method: :post %>
+<%= label_tag :handle %>
+<%= text_field_tag :handle, class: "block col-12 field" %>
+<%= submit_tag 'Send Invite', class: "mt2 btn btn-primary mb1 bg-teal" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,7 @@
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
 
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
+  <%= button_to 'Send Invite', '/invite', method: 'get', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
   post '/login', to: "sessions#create"
   delete '/logout', to: "sessions#destroy"
   get '/activate/:id', to: "activate#create"
+  get '/invite', to: "invites#new", as: 'new_invite'
+  post '/invite', to: "invites#create"
   get 'auth/github', as: 'github_login'
   get '/auth/github/callback', to: 'sessions#github'
 

--- a/spec/features/user/user_can_send_invite_spec.rb
+++ b/spec/features/user/user_can_send_invite_spec.rb
@@ -15,8 +15,16 @@ describe 'A registered user' do
 
       click_on ("Send Invite")
       expect(current_path).to eq('/invite')
-# save_and_open_page
+
       fill_in :handle, with: "kathleen-carroll"
+
+      click_on "Send Invite"
+      expect(current_path).to eq("/dashboard")
+      expect(page).to have_content("Successfully sent invite!")
+      expect(page).to_not have_content("The Github user you selected doesn't have an email address associated with their account.")
+
+      click_on ("Send Invite")
+      fill_in :handle, with: "Will-Meighan"
 
       click_on "Send Invite"
       expect(current_path).to eq("/dashboard")

--- a/spec/features/user/user_can_send_invite_spec.rb
+++ b/spec/features/user/user_can_send_invite_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'A registered user' do
+  scenario 'can send invite' do
+      repo_fixture = File.read('spec/fixtures/repo.json')
+
+      stub_request(:get, "https://api.github.com/user/repos?page=1&per_page=5").
+      to_return(status: 200, body: repo_fixture)
+
+      user = create(:user, token: ENV["GITHUB_TEST_TOKEN_2"])
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/dashboard'
+
+      click_on ("Send Invite")
+      expect(current_path).to eq('/invite')
+# save_and_open_page
+      fill_in :handle, with: "kathleen-carroll"
+
+      click_on "Send Invite"
+      expect(current_path).to eq("/dashboard")
+      expect(page).to have_content("Successfully sent invite!")
+      expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+  end
+end

--- a/spec/features/user/user_can_send_invite_spec.rb
+++ b/spec/features/user/user_can_send_invite_spec.rb
@@ -20,7 +20,7 @@ describe 'A registered user' do
 
       click_on "Send Invite"
       expect(current_path).to eq("/dashboard")
-      expect(page).to have_content("Successfully sent invite!")
+      expect(page).to_not have_content("Successfully sent invite!")
       expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
   end
 end

--- a/spec/mailers/invitation_spec.rb
+++ b/spec/mailers/invitation_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InvitationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/invitation_spec.rb
+++ b/spec/mailers/invitation_spec.rb
@@ -1,5 +1,27 @@
 require "rails_helper"
 
 RSpec.describe InvitationMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "When a user sends an invitation email" do
+    before :each do
+      @user = create(:user, email: "example@gmail.com", username: "kathleen-carroll")
+      @user2 = create(:user, email: "example2@gmail.com", first_name: "Will", last_name: "Meighan")
+      @email = InvitationMailer.invite(@user, @user2)
+    end
+
+    it "has the following subject" do
+      expect(@email.subject).to eql("You've been invited to join Turing Video Tutorials!")
+    end
+
+    it "has the correct sender's email address" do
+      expect(@email.from).to eql(["no-reply@brownfieldofdreams.com"])
+    end
+
+    it "has the correct receiving user's email address" do
+      expect(@email.to).to eql(["#{@user.email}"])
+    end
+
+    it "has the activation url" do
+      expect(@email.body.encoded).to match("/signup")
+    end
+  end
 end

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation
+class InvitationPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
Finish email invitations story
  -Testing invitation mailer and feature testing for sending invitation through the site
  -Add button to dashboard view to invite github user to join via email
  -Input github user handle in form and submit to send email
  -email message handling is done in invites controller
  -message contains link in site to sign up